### PR TITLE
Fix missing tags method check for emptiness and it's use in addArray method.

### DIFF
--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -269,10 +269,10 @@ class SitemapParser
         if ($this->urlValidate($array['loc'])) {
             switch ($type) {
                 case self::XML_TAG_SITEMAP:
-                    $this->sitemaps[$array['loc']] = $this->fixMissingTags(['lastmod', 'changefreq', 'priority'], $array);
+                    $this->sitemaps[$array['loc']] = $this->fixMissingTags(['lastmod'], $array);
                     return true;
                 case self::XML_TAG_URL:
-                    $this->urls[$array['loc']] = $this->fixMissingTags(['lastmod'], $array);
+                    $this->urls[$array['loc']] = $this->fixMissingTags(['lastmod', 'changefreq', 'priority'], $array);
                     return true;
             }
         }
@@ -289,7 +289,7 @@ class SitemapParser
     protected function fixMissingTags(array $tags, array $array)
     {
         foreach ($tags as $tag) {
-            if (empty($array)) {
+            if (empty($array[$tag])) {
                 $array[$tag] = null;
             }
         }


### PR DESCRIPTION
- In **fixMissingTags** method was fixed condition which check if attribute was presented in array. Before this commit functions checks many time if entire array is empty, but not if specific tag was presented in array.

- Also in **addArray** method were swapped tags for fix method.
  - In Sitemap protocol for **url** are required *loc* tags and optional tags are: **lastmod**, **changefreq** and **priority**.
  - For **sitemap** tag is required only **loc** tag and **lastmod** is optional.
  - Based on [Sitemaps XML format](https://www.sitemaps.org/protocol.html)