### PR TITLE
Strip XML Comments

### DIFF
--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -304,6 +304,10 @@ class SitemapParser
      */
     protected function generateXMLObject($xml)
     {
+        // strip XML comments from files
+        // if they occur at the beginning of the file it will invalidate the XML
+        // this occurs with certain versions of Yoast
+        $xml = preg_replace('/\s*\<\!\-\-((?!\-\-\>)[\s\S])*\-\-\>\s*/', '', (string) $xml);
         try {
             libxml_use_internal_errors(true);
             return new SimpleXMLElement($xml, LIBXML_NOCDATA);


### PR DESCRIPTION
Some versions of Yoast will add a comment to the beginning of XML files invalidating the XML. Because of this, the native `SimpleXMLElement` PHP object will fail to parse certain sitemaps. I propose we use regex to strip comments prior to parsing the XML.

Here's my test file:
```
<!-- This page is cached by the Hummingbird Performance plugin v2.0.1 - https://wordpress.org/plugins/hummingbird-performance/. -->
<?xml version="1.0" encoding="UTF-8"?>
    <?xml-stylesheet type="text/xsl" href="//www.bellinghambaymarathon.org/main-sitemap.xsl"?>
        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
            <sitemap>
                <loc>https://www.bellinghambaymarathon.org/post-sitemap.xml</loc>
                <lastmod>2019-07-19T10:18:07-07:00</lastmod>
            </sitemap>
            <sitemap>
                <loc>https://www.bellinghambaymarathon.org/page-sitemap.xml</loc>
                <lastmod>2019-07-29T06:51:35-07:00</lastmod>
            </sitemap>
            <sitemap>
                <loc>https://www.bellinghambaymarathon.org/category-sitemap.xml</loc>
                <lastmod>2019-07-19T10:18:07-07:00</lastmod>
            </sitemap>
            <sitemap>
                <loc>https://www.bellinghambaymarathon.org/post_tag-sitemap.xml</loc>
                <lastmod>2019-05-16T10:06:14-07:00</lastmod>
            </sitemap>
            <sitemap>
                <loc>https://www.bellinghambaymarathon.org/author-sitemap.xml</loc>
                <lastmod>2018-08-22T17:12:52-07:00</lastmod>
            </sitemap>
        </sitemapindex>
<!-- XML Sitemap generated by Yoast SEO --><!-- Hummingbird cache file was created in 1.061126947403 seconds, on 01-08-19 23:06:50 -->
``` 

Here's my test code:
```
$parser = new SitemapParser('SiteMapperAgent');
$parser->parseRecursive("https://www.bellinghambaymarathon.org/sitemap_index.xml");
foreach ($parser->getURLs() as $url => $tags) {
    echo $url . PHP_EOL;
}
```