### PR TITLE
Sitemap Broken Links

### DIFF
--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -217,7 +217,9 @@ class SitemapParser
             $res = $client->request('GET', $this->currentURL, $this->config['guzzle']);
             return $res->getBody();
         } catch (GuzzleHttp\Exception\TransferException $e) {
-            throw new SitemapParserException($e->getMessage());
+            if (stripos($e->getMessage(), 'cURL error 6:') === false && $e->getCode() != 404) {
+                throw new SitemapParserException($e->getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
I think the ideal functionality for recursively parsing cascading sitemaps is if we continue to parse our the URL's even if we encounter a broken link. Here's an example of a sitemap that has a broken link: `https://www.coachforteens.com/sitemap_index.xml`

Currently, it will just completely fail and return 0 URL's. With the new code, it will just skip over the broken URL and return the 560 that aren't broken.