### PR TITLE
Improve type assertions

### DIFF
--- a/tests/DownloadTest.php
+++ b/tests/DownloadTest.php
@@ -15,18 +15,18 @@ class DownloadTest extends TestCase
         $parser = new SitemapParser('SitemapParser');
         $this->assertInstanceOf('vipnytt\SitemapParser', $parser);
         $parser->parse($url);
-        $this->assertTrue(is_array($parser->getSitemaps()));
-        $this->assertTrue(is_array($parser->getURLs()));
+        $this->assertInternalType('array', $parser->getSitemaps());
+        $this->assertInternalType('array', $parser->getURLs());
         $this->assertTrue(count($parser->getSitemaps()) > 0 || count($parser->getURLs()) > 0);
         foreach ($parser->getSitemaps() as $url => $tags) {
-            $this->assertTrue(is_string($url));
-            $this->assertTrue(is_array($tags));
+            $this->assertInternalType('string', $url);
+            $this->assertInternalType('array', $tags);
             $this->assertTrue($url === $tags['loc']);
             $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
         }
         foreach ($parser->getURLs() as $url => $tags) {
-            $this->assertTrue(is_string($url));
-            $this->assertTrue(is_array($tags));
+            $this->assertInternalType('string', $url);
+            $this->assertInternalType('array', $tags);
             $this->assertTrue($url === $tags['loc']);
             $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
         }

--- a/tests/RecursiveTest.php
+++ b/tests/RecursiveTest.php
@@ -16,18 +16,18 @@ class RecursiveTest extends TestCase
         $parser = new SitemapParser('SitemapParser');
         $this->assertInstanceOf('vipnytt\SitemapParser', $parser);
         $parser->parseRecursive($url);
-        $this->assertTrue(is_array($parser->getSitemaps()));
-        $this->assertTrue(is_array($parser->getURLs()));
+        $this->assertInternalType('array', $parser->getSitemaps());
+        $this->assertInternalType('array', $parser->getURLs());
         $this->assertTrue(count($parser->getSitemaps()) > 1 || count($parser->getURLs()) > 100);
         foreach ($parser->getSitemaps() as $url => $tags) {
-            $this->assertTrue(is_string($url));
-            $this->assertTrue(is_array($tags));
+            $this->assertInternalType('string', $url);
+            $this->assertInternalType('array', $tags);
             $this->assertTrue($url === $tags['loc']);
             $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
         }
         foreach ($parser->getURLs() as $url => $tags) {
-            $this->assertTrue(is_string($url));
-            $this->assertTrue(is_array($tags));
+            $this->assertInternalType('string', $url);
+            $this->assertInternalType('array', $tags);
             $this->assertTrue($url === $tags['loc']);
             $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
         }

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -16,19 +16,19 @@ class StringTest extends TestCase
         $parser = new SitemapParser('SitemapParser', ['strict' => false]);
         $this->assertInstanceOf('vipnytt\SitemapParser', $parser);
         $parser->parse($url);
-        $this->assertTrue(is_array($parser->getSitemaps()));
-        $this->assertTrue(is_array($parser->getURLs()));
+        $this->assertInternalType('array', $parser->getSitemaps());
+        $this->assertInternalType('array', $parser->getURLs());
         $this->assertTrue(count($parser->getSitemaps()) > 1);
         $this->assertTrue(count($parser->getURLs()) >= 1000);
         foreach ($parser->getSitemaps() as $url => $tags) {
-            $this->assertTrue(is_string($url));
-            $this->assertTrue(is_array($tags));
+            $this->assertInternalType('string', $url);
+            $this->assertInternalType('array', $tags);
             $this->assertTrue($url === $tags['loc']);
             $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
         }
         foreach ($parser->getURLs() as $url => $tags) {
-            $this->assertTrue(is_string($url));
-            $this->assertTrue(is_array($tags));
+            $this->assertInternalType('string', $url);
+            $this->assertInternalType('array', $tags);
             $this->assertTrue($url === $tags['loc']);
             $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
         }


### PR DESCRIPTION
# Changed log

- Using the `assertInternalType` to assert expected type is same as result.