### PR TITLE
Allow php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     }
   ],
   "require": {
-    "php": "^5.6 || ^7.0",
+    "php": "^5.6 || ^7.0 || ^8.0",
     "guzzlehttp/guzzle": "^6.0 || ^7.0",
     "ext-mbstring": "*",
     "ext-simplexml": "*",


### PR DESCRIPTION
Marks PHP8 as supported in composer.json. As Guzzle7 is already supported, this works fine :)