### PR TITLE
Added XML namespace support

### DIFF
--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -370,6 +370,27 @@ class SitemapParser
     }
 
     /**
+     * Convert object to array recursively
+     *
+     * @param $object
+     * @return array
+     */
+    protected function objectToArray($object)
+    {
+        if (is_object($object) || is_array($object)) {
+            $ret = (array)$object;
+
+            foreach($ret as &$item) {
+                $item = $this->objectToArray($item);
+            }
+
+            return $ret;
+        } else {
+            return $object;
+        }
+    }
+
+    /**
      * Parse Json object
      *
      * @param string $type Sitemap or URL
@@ -381,9 +402,36 @@ class SitemapParser
         if (!isset($json->$type)) {
             return false;
         }
-        foreach ($json->$type as $url) {
-            $this->addArray($type, (array)$url);
+
+	$nameSpaces = $json->getDocNamespaces();
+
+        if (!empty($nameSpaces)) {
+            $tags = ["namespaces" => []];
+
+            foreach ($json->$type as $node) {
+                foreach ($nameSpaces as $nameSpace => $value) {
+                    if ($nameSpace != "") {
+                        $tags["namespaces"] = array_merge(
+                            $tags["namespaces"],
+                            [
+                                $nameSpace => $this->objectToArray(
+                                    $node->children($nameSpace, true)
+                                )
+                            ]
+                        );
+                    } else {
+                        $tags = array_merge($tags, (array)$node);
+                    }
+                }
+
+                $this->addArray($type, $tags);
+            }
+        } else {
+            foreach ($json->$type as $node) {
+                $this->addArray($type, (array)$node);
+            }
         }
+
         return true;
     }
 


### PR DESCRIPTION
Lot of sitemap files have additional namespaced tags such as <imge:image>, <news:news>
This fix added XML namespace support to operate with such tags.

function `$parser->getURLs()` now returns additional element called `namespaces` with nested tags:
```
array:5 [
  "namespaces" => array:1 [
    "news" => array:1 [
      "news" => array:4 [
        "publication" => array:2 [
          "name" => "Some News"
          "language" => "en"
        ]
        "publication_date" => "2022-03-08"
        "title" => "Some title"
        "keywords" => "uk_news"
      ]
    ]
  ]
  "loc" => "https://sample.com/story/story-1.html"
  "lastmod" => null
  "changefreq" => null
  "priority" => null
]
```