### PR TITLE
[FIX] clean sitemaps and urls properties at the start of parseRecursive ...

### DIFF
--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -124,6 +124,7 @@ class SitemapParser
     public function parseRecursive($url)
     {
         $this->addToQueue([$url]);
+        $this->clean();
         while (count($todo = $this->getQueue()) > 0) {
             $sitemaps = $this->sitemaps;
             $urls = $this->urls;


### PR DESCRIPTION
to prevent dirty data at the second call.