### PR TITLE
Move tags init to prevent tag keys persisting.

### DIFF
--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -404,12 +404,11 @@ class SitemapParser
             return false;
         }
 
-	$nameSpaces = $json->getDocNamespaces();
+        $nameSpaces = $json->getDocNamespaces();
 
         if (!empty($nameSpaces)) {
-            $tags = ["namespaces" => []];
-
             foreach ($json->$type as $node) {
+                $tags = ["namespaces" => []];
                 foreach ($nameSpaces as $nameSpace => $value) {
                     if ($nameSpace != "") {
                         $tags["namespaces"] = array_merge(


### PR DESCRIPTION
In a case where tags are missing from items, they are currently populated by the previous items values. eg:
```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
<url><loc>https://testing.ddev.site/lorem</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
<url><loc>https://testing.ddev.site/ipsum</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
<url><loc>https://testing.ddev.site/dolor</loc><changefreq>monthly</changefreq><priority>0.2</priority></url>
<url><changefreq>monthly</changefreq><priority>0.8</priority></url>
<url><loc>https://testing.ddev.site/sit</loc></url>
</urlset>
```
This change ensures tags are reset for each item.