### PR TITLE
Add URL blacklist validation and configure methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The [Sitemaps.org](http://www.sitemaps.org/) protocol is the leading standard an
 - String parsing
 - Custom User-Agent string
 - Proxy support
+- URL blacklist
 
 ## Formats supported
 - XML `.xml`
@@ -91,7 +92,9 @@ try {
 ```
 
 ### Recursive
-Parses any sitemap detected while parsing, to get an complete list of URLs
+Parses any sitemap detected while parsing, to get an complete list of URLs.
+
+Use `url_black_list` to skip sitemaps that are part of parent sitemap. Exact match only.
 ```php
 use vipnytt\SitemapParser;
 use vipnytt\SitemapParser\Exceptions\SitemapParserException;
@@ -152,6 +155,8 @@ $config = [
         // GuzzleHttp request options
         // http://docs.guzzlephp.org/en/latest/request-options.html
     ],
+    // use this to ignore URL when parsing sitemaps that contain multiple other sitemaps. Exact match only.
+    'url_black_list' => []
 ];
 $parser = new SitemapParser('MyCustomUserAgent', $config);
 ```

--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -454,4 +454,41 @@ class SitemapParser
     {
         return $this->urls;
     }
+
+    /**
+     * Get config
+     *
+     * @return array
+     */
+    public function getConfig(): array {
+        return $this->config;
+    }
+
+    /**
+     * Set config
+     *
+     * @param array $config
+     * @return void
+     */
+    public function setConfig(array $config): void {
+        $this->config = $config;
+    }
+
+    /**
+     * Get user agent
+     *
+     * @return string
+     */
+    public function getUserAgent(): string {
+        return $this->userAgent;
+    }
+
+    /**
+     * Change user agent after object creation
+     *
+     * @param string $userAgent
+     */
+    public function setUserAgent(string $userAgent): void {
+        $this->userAgent = $userAgent;
+    }
 }

--- a/src/SitemapParser/UrlParser.php
+++ b/src/SitemapParser/UrlParser.php
@@ -55,7 +55,8 @@ trait UrlParser
             filter_var($url, FILTER_VALIDATE_URL) &&
             ($parsed = parse_url($url)) !== false &&
             $this->urlValidateHost($parsed['host']) &&
-            $this->urlValidateScheme($parsed['scheme'])
+            $this->urlValidateScheme($parsed['scheme']) &&
+            $this->urlValidateAgainstBlackList($url)
         );
     }
 
@@ -89,5 +90,14 @@ trait UrlParser
                 'https',
             ]
         );
+    }
+
+    protected function urlValidateAgainstBlackList($url)
+    {
+        if (empty($this->config['url_black_list'])) {
+            return true;
+        }
+
+        return !in_array($url, $this->config['url_black_list'], true);
     }
 }


### PR DESCRIPTION
Added a blacklist validation feature for URLs to UrlParser class. 

The URL now checks against a blacklist before being validated. Further, accessor and mutator methods for the object's config and user agent values have been introduced to the SitemapParser. It is useful when using dependency injection to change object after injection.