### PR TITLE
Change client creation to allow override

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,9 @@
     "psr-4": {
       "vipnytt\\SitemapParser\\Tests\\": "tests/"
     }
+  },
+  "suggest": {
+    "caseyamcl/guzzle_retry_middleware": "Allow automatic retry when request for sitemap fails",
+    "hamburgscleanest/guzzle-advanced-throttle": "Throttle requests"
   }
 }

--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -98,13 +98,18 @@ class SitemapParser
     protected $currentURL;
 
     /**
+     * @var \GuzzleHttp\Client
+     */
+    protected $client;
+
+    /**
      * Constructor
      *
      * @param string $userAgent User-Agent to send with every HTTP(S) request
      * @param array $config Configuration options
      * @throws Exceptions\SitemapParserException
      */
-    public function __construct($userAgent = self::DEFAULT_USER_AGENT, array $config = [])
+    public function __construct($userAgent = self::DEFAULT_USER_AGENT, array $config = [], GuzzleHttp\Client $client)
     {
         mb_language("uni");
         if (!mb_internal_encoding(self::ENCODING)) {
@@ -112,6 +117,8 @@ class SitemapParser
         }
         $this->userAgent = $userAgent;
         $this->config = $config;
+
+        $this->setClient($client);
     }
 
     /**
@@ -237,7 +244,7 @@ class SitemapParser
             if (!isset($this->config['guzzle']['headers']['User-Agent'])) {
                 $this->config['guzzle']['headers']['User-Agent'] = $this->userAgent;
             }
-            $client = new GuzzleHttp\Client();
+            $client = $this->getClient();
             $res = $client->request('GET', $this->currentURL, $this->config['guzzle']);
             return $res->getBody()->getContents();
         } catch (GuzzleHttp\Exception\TransferException $e) {
@@ -500,5 +507,26 @@ class SitemapParser
      */
     public function setUserAgent(string $userAgent): void {
         $this->userAgent = $userAgent;
+    }
+
+    /**
+     * @return \GuzzleHttp\Client
+     */
+    protected function getClient()
+    {
+        if (empty($this->client)) {
+            $this->client = new \GuzzleHttp\Client();
+        }
+        return $this->client;
+    }
+
+    /**
+     * @param mixed $client
+     * @return $this
+     */
+    public function setClient(\GuzzleHttp\Client $client)
+    {
+        $this->client = $client;
+        return $this;
     }
 }


### PR DESCRIPTION
The SitemapParser constructor now accepts a GuzzleHttp client as a parameter, improving flexibility and testability

The README and composer.json have been updated to suggest middleware for automatic retries on failed requests, and for throttling requests to prevent rate limit issues. Detailed instructions for implementation of these middlewares have been added to the README file.